### PR TITLE
Update standard-dependent-resources.bicep to remove statistics setting

### DIFF
--- a/infra/agent/standard-dependent-resources.bicep
+++ b/infra/agent/standard-dependent-resources.bicep
@@ -95,7 +95,6 @@ resource aiServices 'Microsoft.CognitiveServices/accounts@2024-06-01-preview' = 
   properties: {
     customSubDomainName: toLower('${(aiServicesName)}')
     apiProperties: {
-      statisticsEnabled: false
     }
     publicNetworkAccess: 'Enabled'
   }


### PR DESCRIPTION
Remove the statistics setting from the standard-dependent-resources.bicep file as it was causing an issue.

Not impacting as it was set to false.